### PR TITLE
Add WiFi with hotspot fallback and configuration page

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -18,4 +18,3 @@ lib_deps =
   adafruit/Adafruit MAX31855 library
   adafruit/Adafruit SSD1306
   adafruit/Adafruit GFX Library
-  arduino-libraries/Ethernet

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -1,27 +1,93 @@
 #include "Network.h"
-#include <SPI.h>
-#include <Ethernet.h>
-#include "Pins.h"
+#include "Thermocouple.h"
 
-// MAC and static IP
-static byte mac[] = { 0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED };
-static IPAddress staticIP(192, 168, 1, 177);
+#include <WiFi.h>
+#include <WebServer.h>
+#include <Preferences.h>
+
+static Preferences prefs;
+static WebServer server(80);
+
+static String ssid;
+static String pass;
+
+static void handleRoot() {
+  double temp = readTemperature();
+  String page = "<html><body><h1>WiFi Config</h1>";
+  page += "<form method='POST' action='/save'>";
+  page += "SSID: <input name='ssid' value='" + ssid + "'><br>";
+  page += "Password: <input name='pass' type='password'><br>";
+  page += "<input type='submit' value='Save'></form>";
+  page += "<p>Temperature: " + String(temp) + " C</p>";
+  page += "</body></html>";
+  server.send(200, "text/html", page);
+}
+
+static void handleSave() {
+  if (server.hasArg("ssid") && server.hasArg("pass")) {
+    ssid = server.arg("ssid");
+    pass = server.arg("pass");
+    prefs.putString("ssid", ssid);
+    prefs.putString("pass", pass);
+    server.send(200, "text/html", "Saved. Rebooting...");
+    delay(500);
+    ESP.restart();
+  } else {
+    server.send(400, "text/plain", "Missing params");
+  }
+}
+
+static void startAP() {
+  WiFi.mode(WIFI_AP);
+  WiFi.softAP("ESP32-Setup");
+  server.on("/", handleRoot);
+  server.on("/save", HTTP_POST, handleSave);
+  server.begin();
+  Serial.println("Started AP for configuration");
+}
+
+static void startServer() {
+  server.on("/", handleRoot);
+  server.on("/save", HTTP_POST, handleSave);
+  server.begin();
+}
 
 void setupNetwork() {
-  Ethernet.init(CS_W5500);
-  if (Ethernet.begin(mac) == 0) {
-    Serial.println("Ethernet DHCP failed, using static IP.");
-    Ethernet.begin(mac, staticIP);
+  prefs.begin("wifi", false);
+  ssid = prefs.getString("ssid", "");
+  pass = prefs.getString("pass", "");
+
+  if (ssid.length() > 0) {
+    WiFi.mode(WIFI_STA);
+    WiFi.begin(ssid.c_str(), pass.c_str());
+    unsigned long start = millis();
+    while (WiFi.status() != WL_CONNECTED && millis() - start < 10000) {
+      delay(500);
+    }
+    if (WiFi.status() == WL_CONNECTED) {
+      Serial.print("WiFi connected: ");
+      Serial.println(WiFi.localIP());
+      startServer();
+      return;
+    }
+    Serial.println("WiFi connection failed");
   }
-  delay(1000);
-  Serial.print("IP Address: ");
-  Serial.println(Ethernet.localIP());
+
+  startAP();
 }
 
 IPAddress getLocalIP() {
-  return Ethernet.localIP();
+  if (WiFi.status() == WL_CONNECTED) {
+    return WiFi.localIP();
+  }
+  return WiFi.softAPIP();
 }
 
 bool isNetworkUp() {
-  return Ethernet.linkStatus() == LinkON && Ethernet.localIP()[0] != 0;
+  return WiFi.status() == WL_CONNECTED;
 }
+
+void handleNetwork() {
+  server.handleClient();
+}
+

--- a/src/Network.h
+++ b/src/Network.h
@@ -6,5 +6,6 @@
 void setupNetwork();
 IPAddress getLocalIP();
 bool isNetworkUp();
+void handleNetwork();
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,6 +69,7 @@ void loop() {
   }
 
   showStatusDisplay(temperature, status, sdstatus);
+  handleNetwork();
   delay(500);
 }
 


### PR DESCRIPTION
## Summary
- Replace Ethernet networking with WiFi support and fallback AP for configuration
- Expose minimal web UI to configure SSID/password and read current temperature
- Remove unused Ethernet library dependency

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897574c935c832ab0755de2dbe64918